### PR TITLE
Add product detail page and shopping cart support

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -2,7 +2,9 @@ const mongoose = require('mongoose');
 
 const UserSchema = new mongoose.Schema({
   username: { type: String, required: true, unique: true },
-  password: { type: String, required: true }
+  password: { type: String, required: true },
+  // Array of products added to the user's shopping cart
+  cart: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Product', default: [] }]
 });
 
 module.exports = mongoose.model('User', UserSchema);

--- a/public/product.html
+++ b/public/product.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="fa">
+<head>
+  <meta charset="UTF-8" />
+  <title>جزئیات محصول</title>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <style>
+    body { font-family: Tahoma, sans-serif; direction: rtl; padding: 20px; }
+    img { max-width: 100%; height: auto; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" src="product.js"></script>
+</body>
+</html>

--- a/public/product.js
+++ b/public/product.js
@@ -1,0 +1,45 @@
+const { useEffect, useState } = React;
+
+function ProductDetail() {
+  const [product, setProduct] = useState(null);
+  const token = localStorage.getItem('token');
+  const params = new URLSearchParams(window.location.search);
+  const id = params.get('id');
+
+  useEffect(() => {
+    if (!token) {
+      window.location.href = '/';
+      return;
+    }
+    fetch(`/api/products/${id}`, {
+      headers: { Authorization: `Bearer ${token}` }
+    })
+      .then(res => res.json())
+      .then(setProduct);
+  }, [id, token]);
+
+  const addToCart = () => {
+    fetch('/api/cart', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({ productId: id })
+    }).then(() => alert('به سبد خرید اضافه شد'));
+  };
+
+  if (!product) return <div>در حال بارگذاری...</div>;
+
+  return (
+    <div>
+      <h2>{product.name}</h2>
+      <img src={product.imageUrl} alt={product.name} />
+      <p>{product.description}</p>
+      <p>{product.price} تومان</p>
+      <button onClick={addToCart}>افزودن به سبد خرید</button>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<ProductDetail />);

--- a/public/products.js
+++ b/public/products.js
@@ -21,13 +21,22 @@ function Products() {
     window.location.href = '/';
   };
 
+  const viewProduct = id => {
+    window.location.href = `/product.html?id=${id}`;
+  };
+
   return (
     <div>
       <button onClick={logout}>خروج</button>
       <h2>محصولات</h2>
       <div className="grid">
         {products.map(p => (
-          <div key={p._id} className="product">
+          <div
+            key={p._id}
+            className="product"
+            onClick={() => viewProduct(p._id)}
+            style={{ cursor: 'pointer' }}
+          >
             <img src={p.imageUrl} alt={p.name} />
             <h3>{p.name}</h3>
             <p>{p.price} تومان</p>

--- a/server.js
+++ b/server.js
@@ -85,5 +85,32 @@ app.get('/api/products', async (req, res) => {
   res.json(products);
 });
 
+// Get a single product by id
+app.get('/api/products/:id', async (req, res) => {
+  try {
+    const product = await Product.findById(req.params.id);
+    if (!product) return res.status(404).json({ message: 'not found' });
+    res.json(product);
+  } catch (err) {
+    res.status(400).json({ message: 'invalid id' });
+  }
+});
+
+// Add a product to the authenticated user's cart
+app.post('/api/cart', authMiddleware, async (req, res) => {
+  const { productId } = req.body;
+  if (!productId) return res.status(400).json({ message: 'productId required' });
+  const user = await User.findById(req.user.id);
+  user.cart.push(productId);
+  await user.save();
+  res.json({ message: 'added to cart' });
+});
+
+// Get the authenticated user's cart
+app.get('/api/cart', authMiddleware, async (req, res) => {
+  const user = await User.findById(req.user.id).populate('cart');
+  res.json(user.cart);
+});
+
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- track items per user by adding `cart` field to user schema and backend cart routes
- expose product detail API and frontend page with add-to-cart button
- allow clicking products to navigate to detail page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68990a3b8fb88332986f67411163232c