### PR TITLE
Stack product list and center login form with image

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,11 +7,32 @@
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
   <style>
-    body { font-family: Tahoma, sans-serif; direction: rtl; padding: 20px; }
-    form { margin-bottom: 20px; }
-    .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 20px; }
-    .product { border: 1px solid #ccc; padding: 10px; border-radius: 8px; text-align: center; }
-    .product img { max-width: 100%; height: auto; }
+    body {
+      font-family: Tahoma, sans-serif;
+      direction: rtl;
+      margin: 0;
+      height: 100vh;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+    .login-wrapper {
+      display: flex;
+      align-items: center;
+      gap: 20px;
+    }
+    .login-form {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    .login-form input {
+      margin-bottom: 10px;
+    }
+    .login-image {
+      max-width: 150px;
+      height: auto;
+    }
   </style>
 </head>
 <body>

--- a/public/login.js
+++ b/public/login.js
@@ -29,21 +29,24 @@ function Login() {
   };
 
   return (
-    <form onSubmit={submit}>
-      <input
-        placeholder="نام کاربری"
-        value={username}
-        onChange={e => setUsername(e.target.value)}
-      />
-      <input
-        type="password"
-        placeholder="رمز عبور"
-        value={password}
-        onChange={e => setPassword(e.target.value)}
-      />
-      <button type="submit">ورود</button>
-      {error && <p>{error}</p>}
-    </form>
+    <div className="login-wrapper">
+      <img src="my_photo.jpeg" alt="login" className="login-image" />
+      <form onSubmit={submit} className="login-form">
+        <input
+          placeholder="نام کاربری"
+          value={username}
+          onChange={e => setUsername(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="رمز عبور"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+        <button type="submit">ورود</button>
+        {error && <p>{error}</p>}
+      </form>
+    </div>
   );
 }
 

--- a/public/products.html
+++ b/public/products.html
@@ -8,7 +8,11 @@
   <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
   <style>
     body { font-family: Tahoma, sans-serif; direction: rtl; padding: 20px; }
-    .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 20px; }
+    .grid {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
     .product { border: 1px solid #ccc; padding: 10px; border-radius: 8px; text-align: center; }
     .product img { max-width: 100%; height: auto; }
   </style>


### PR DESCRIPTION
## Summary
- Display products in a vertical list for easier reading.
- Center the login form with stacked fields and show a side image.
- Remove `public/my_photo.jpeg` so the image can be supplied manually.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689914cabaa883328a786e04a36c1e17